### PR TITLE
fix array_key_exists() function error forcing json_decode() to return an array

### DIFF
--- a/grade/grading/form/erubric/lib.php
+++ b/grade/grading/form/erubric/lib.php
@@ -511,7 +511,7 @@ class gradingform_erubric_controller extends gradingform_controller {
     public function get_options() {
         $options = self::get_default_options();
         if (!empty($this->definition->options)) {
-            $thisoptions = json_decode($this->definition->options);
+            $thisoptions = json_decode($this->definition->options, true);
             foreach ($thisoptions as $option => $value) {
                 $options[$option] = $value;
             }


### PR DESCRIPTION
*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
